### PR TITLE
Speed up report

### DIFF
--- a/src/Domain.LinnApps/Domain.LinnApps.csproj
+++ b/src/Domain.LinnApps/Domain.LinnApps.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Linn.Common.Reporting" Version="1.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Repositories\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Domain.LinnApps/Domain.LinnApps.csproj
+++ b/src/Domain.LinnApps/Domain.LinnApps.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -10,10 +10,6 @@
     <PackageReference Include="Linn.Common.Domain" Version="1.0.0" />
     <PackageReference Include="Linn.Common.Persistence" Version="2.0.1" />
     <PackageReference Include="Linn.Common.Reporting" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Repositories\" />
   </ItemGroup>
 
 </Project>

--- a/src/Domain.LinnApps/RemoteServices/IBuildsSummariesRepository.cs
+++ b/src/Domain.LinnApps/RemoteServices/IBuildsSummariesRepository.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     public interface IBuildsRepository
     {

--- a/src/Domain.LinnApps/RemoteServices/IBuildsSummariesRepository.cs
+++ b/src/Domain.LinnApps/RemoteServices/IBuildsSummariesRepository.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Collections.Generic;
 
-    public interface IBuildsRepository
+    public interface IBuildsSummariesRepository
     {
-        IEnumerable<BuildsSummary> GetBuildsByDepartment(DateTime from, DateTime to, bool monthly = false);
+        IEnumerable<BuildsSummary> GetBuildsSummaries(DateTime from, DateTime to, bool monthly = false);
     }
 }

--- a/src/Domain.LinnApps/RemoteServices/IBuildsSummaryReportDatabaseService.cs
+++ b/src/Domain.LinnApps/RemoteServices/IBuildsSummaryReportDatabaseService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Linn.Production.Domain.LinnApps.Reports
+{
+    public interface IBuildsSummaryReportDatabaseService
+    {
+        IEnumerable<BuildsSummary> GetBuildsSummaries(DateTime from, DateTime to, bool monthly);
+    }
+}

--- a/src/Domain.LinnApps/Services/BuildsSummaryReportService.cs
+++ b/src/Domain.LinnApps/Services/BuildsSummaryReportService.cs
@@ -1,30 +1,28 @@
-﻿namespace Linn.Production.Domain.LinnApps.Services
+﻿using Linn.Production.Domain.LinnApps.Reports;
+
+namespace Linn.Production.Domain.LinnApps.Services
 {
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-
-    using Linn.Common.Persistence;
     using Linn.Common.Reporting.Models;
-    using Linn.Production.Domain.LinnApps.RemoteServices;
-    using Linn.Production.Domain.LinnApps.Repositories;
 
-    public class BuildsByDepartmentReportService : IBuildsByDepartmentReportService
+
+    public class BuildsSummaryReportService : IBuildsSummaryReportService
     {
-        private readonly IBuildsRepository buildsRepository;
+        private readonly IBuildsSummaryReportDatabaseService databaseService;
 
-        private readonly IRepository<Department, string> departmentRepository;
-
-        public BuildsByDepartmentReportService(IBuildsRepository buildsRepository, ILrpPack lrpPack, IRepository<Department, string> departmentRepository)
+        public BuildsSummaryReportService(
+            IBuildsSummaryReportDatabaseService databaseService)
         {
-            this.buildsRepository = buildsRepository;
-            this.departmentRepository = departmentRepository;
+            this.databaseService = databaseService;
         }
 
         public IEnumerable<ResultsModel> GetBuildsSummaryReports(DateTime from, DateTime to, bool monthly = false)
         {
-            var summaries = this.buildsRepository.GetBuildsByDepartment(from, to, monthly).ToList();
+            var summaries = this.databaseService.GetBuildsSummaries(from, to, monthly).ToList(); // enumerate here
+            
             var weeks = summaries.GroupBy(s => s.WeekEnd.Date);
             var reports = new List<ResultsModel>();
             foreach (var week in weeks)
@@ -45,7 +43,7 @@
                     results.SetColumnType(2, GridDisplayType.Value);
 
                     var row = results.AddRow(summary.Department);
-                    results.SetGridTextValue(row.RowIndex, 0, this.departmentRepository.FindById(summary.Department).Description);
+                    results.SetGridTextValue(row.RowIndex, 0, summary.Department); // is this a code??
                     results.SetGridValue(row.RowIndex, 1, summary.Value, decimalPlaces: 1);
                     results.SetGridValue(row.RowIndex, 2, summary.DaysToBuild, decimalPlaces: 1);
                 }
@@ -76,7 +74,7 @@
                 results.SetColumnType(2, GridDisplayType.Value);
 
                 var row = results.AddRow(department.Key);
-                results.SetGridTextValue(row.RowIndex, 0, this.departmentRepository.FindById(department.Key).Description);
+                results.SetGridTextValue(row.RowIndex, 0, department.Key); // what is key??
                 results.SetGridValue(row.RowIndex, 1, department.TotalValue, decimalPlaces: 1);
                 results.SetGridValue(row.RowIndex, 2, department.TotalDays, decimalPlaces: 1);
             }

--- a/src/Domain.LinnApps/Services/BuildsSummaryReportService.cs
+++ b/src/Domain.LinnApps/Services/BuildsSummaryReportService.cs
@@ -6,7 +6,7 @@ namespace Linn.Production.Domain.LinnApps.Services
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    using Linn.Common.Reporting.Models;
+    using Common.Reporting.Models;
 
 
     public class BuildsSummaryReportService : IBuildsSummaryReportService
@@ -21,7 +21,7 @@ namespace Linn.Production.Domain.LinnApps.Services
 
         public IEnumerable<ResultsModel> GetBuildsSummaryReports(DateTime from, DateTime to, bool monthly = false)
         {
-            var summaries = this.databaseService.GetBuildsSummaries(from, to, monthly).ToList(); // enumerate here
+            var summaries = this.databaseService.GetBuildsSummaries(from, to, monthly).ToList();
             
             var weeks = summaries.GroupBy(s => s.WeekEnd.Date);
             var reports = new List<ResultsModel>();
@@ -43,7 +43,7 @@ namespace Linn.Production.Domain.LinnApps.Services
                     results.SetColumnType(2, GridDisplayType.Value);
 
                     var row = results.AddRow(summary.Department);
-                    results.SetGridTextValue(row.RowIndex, 0, summary.Department); // is this a code??
+                    results.SetGridTextValue(row.RowIndex, 0, summary.Department);
                     results.SetGridValue(row.RowIndex, 1, summary.Value, decimalPlaces: 1);
                     results.SetGridValue(row.RowIndex, 2, summary.DaysToBuild, decimalPlaces: 1);
                 }
@@ -74,7 +74,7 @@ namespace Linn.Production.Domain.LinnApps.Services
                 results.SetColumnType(2, GridDisplayType.Value);
 
                 var row = results.AddRow(department.Key);
-                results.SetGridTextValue(row.RowIndex, 0, department.Key); // what is key??
+                results.SetGridTextValue(row.RowIndex, 0, department.Key);
                 results.SetGridValue(row.RowIndex, 1, department.TotalValue, decimalPlaces: 1);
                 results.SetGridValue(row.RowIndex, 2, department.TotalDays, decimalPlaces: 1);
             }

--- a/src/Domain.LinnApps/Services/IBuildsSummaryReportService.cs
+++ b/src/Domain.LinnApps/Services/IBuildsSummaryReportService.cs
@@ -1,12 +1,11 @@
 ﻿namespace Linn.Production.Domain.LinnApps.Services
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
 
     using Linn.Common.Reporting.Models;
 
-    public interface IBuildsByDepartmentReportService
+    public interface IBuildsSummaryReportService
     {
         IEnumerable<ResultsModel> GetBuildsSummaryReports(DateTime from, DateTime to, bool monthly = false);
     }

--- a/src/Facade/Services/BuildsByDepartmentReportFacadeService.cs
+++ b/src/Facade/Services/BuildsByDepartmentReportFacadeService.cs
@@ -11,17 +11,17 @@
 
     public class BuildsByDepartmentReportFacadeService : IBuildsByDepartmentReportFacadeService
     {
-        private readonly IBuildsByDepartmentReportService buildsByDepartmentReportService;
+        private readonly IBuildsSummaryReportService buildsSummaryReportService;
 
         public BuildsByDepartmentReportFacadeService(
-            IBuildsByDepartmentReportService buildsByDepartmentReportService)
+            IBuildsSummaryReportService buildsSummaryReportService)
         {
-            this.buildsByDepartmentReportService = buildsByDepartmentReportService;
+            this.buildsSummaryReportService = buildsSummaryReportService;
         }
 
         public IResult<IEnumerable<ResultsModel>> GetBuildsSummaryReports(DateTime fromWeek, DateTime toWeek, bool monthly = false)
         {
-            return new SuccessResult<IEnumerable<ResultsModel>>(this.buildsByDepartmentReportService.GetBuildsSummaryReports(fromWeek, toWeek, monthly));
+            return new SuccessResult<IEnumerable<ResultsModel>>(this.buildsSummaryReportService.GetBuildsSummaryReports(fromWeek, toWeek, monthly));
         }
     }
 }

--- a/src/IoC/PersistenceModule.cs
+++ b/src/IoC/PersistenceModule.cs
@@ -21,7 +21,7 @@
             builder.RegisterType<TransactionManager>().As<ITransactionManager>();
 
             // linnapps repositories
-            builder.RegisterType<BuildsRepository>().As<IBuildsRepository>();
+            builder.RegisterType<BuildsSummariesRepository>().As<IBuildsSummariesRepository>();
             builder.RegisterType<DepartmentsRepository>().As<IRepository<Department, string>>();
 
             builder.RegisterType<AteFaultCodeRepository>().As<IRepository<AteFaultCode, string>>();

--- a/src/IoC/ServiceModule.cs
+++ b/src/IoC/ServiceModule.cs
@@ -19,7 +19,7 @@
         protected override void Load(ContainerBuilder builder)
         {
             // domain services
-            builder.RegisterType<BuildsByDepartmentReportService>().As<IBuildsByDepartmentReportService>();
+            builder.RegisterType<BuildsSummaryReportService>().As<IBuildsSummaryReportService>();
 
             // facade services
             builder.RegisterType<BuildsByDepartmentReportFacadeService>().As<IBuildsByDepartmentReportFacadeService>();
@@ -38,6 +38,7 @@
             builder.RegisterType<DatabaseService>().As<IDatabaseService>();
             builder.RegisterType<OutstandingWorksOrdersReportProxy>()
                 .As<IOutstandindWorksOrdersReportDatabaseService>();
+            builder.RegisterType<BuildsSummaryReportProxy>().As<IBuildsSummaryReportDatabaseService>();
 
             builder.RegisterType<OracleConnection>().As<IDbConnection>().WithParameter("connectionString", ConnectionStrings.ManagedConnectionString());
             builder.RegisterType<OracleCommand>().As<IDbCommand>();

--- a/src/Persistence.LinnApps/Repositories/BuildsSummariesRepository.cs
+++ b/src/Persistence.LinnApps/Repositories/BuildsSummariesRepository.cs
@@ -8,23 +8,21 @@
     using Domain.LinnApps.RemoteServices;
     using Domain.LinnApps.Repositories;
 
-    using Microsoft.EntityFrameworkCore;
-
-    public class BuildsRepository : IBuildsRepository
+    public class BuildsSummariesRepository : IBuildsSummariesRepository
     {
         private readonly ServiceDbContext serviceDbContext;
         private readonly ILrpPack lrpPack;
 
         private readonly ILinnWeekPack weekPack;
 
-        public BuildsRepository(ServiceDbContext serviceDbContext, ILrpPack lrpPack, ILinnWeekPack weekPack)
+        public BuildsSummariesRepository(ServiceDbContext serviceDbContext, ILrpPack lrpPack, ILinnWeekPack weekPack)
         {
             this.serviceDbContext = serviceDbContext;
             this.lrpPack = lrpPack;
             this.weekPack = weekPack;
         }
 
-        public IEnumerable<BuildsSummary> GetBuildsByDepartment(DateTime from, DateTime to, bool monthly = false)
+        public IEnumerable<BuildsSummary> GetBuildsSummaries(DateTime from, DateTime to, bool monthly = false)
         {
             return this.serviceDbContext.Builds
                 .Where(b => b.BuildDate > from && b.BuildDate < to)

--- a/src/Proxy/BuildsSummaryReportProxy.cs
+++ b/src/Proxy/BuildsSummaryReportProxy.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Linn.Production.Domain.LinnApps;
+using Linn.Production.Domain.LinnApps.Reports;
+
+namespace Linn.Production.Proxy
+{
+    public class BuildsSummaryReportProxy : IBuildsSummaryReportDatabaseService
+    {
+        private readonly IDatabaseService db;
+
+        public BuildsSummaryReportProxy(IDatabaseService db)
+        {
+            this.db = db;
+        }
+
+        public IEnumerable<BuildsSummary> GetBuildsSummaries(DateTime from, DateTime to, bool monthly)
+        {
+            var dateSelect = monthly
+                ? "last_day(trunc(a.bu_date)),"
+                : "linn_week_pack.linn_week_end_date(trunc(bu_date)) week_end,";
+
+            var groupByClause = monthly 
+                ? "last_day(TRUNC(bu_date))"
+                : "linn_week_pack.linn_week_end_date(trunc(bu_date)) ";
+
+            var sql = $@"select 
+                        d.description,
+                        a.CR_DEPT,
+                        {dateSelect}
+                        round(sum (material_price + labour_price ),1) value,
+                        round(sum(lrp_pack.days_to_build_part(a.part_number,a.QUANTITY )), 1) mins 
+                        from v_builds a,linn_departments d
+                        where a.cr_dept = d.DEPARTMENT_CODE
+                        and bu_date between trunc(to_date('{from.ToShortDateString()}', 'dd/mm/yyyy')) 
+                        and trunc(to_date('{to.ToShortDateString()}', 'dd/mm/yyyy')) + 1
+                        group by a.cr_dept,
+                        d.description,
+                        {groupByClause}
+                        order by 2 asc";
+
+            var table = this.db.ExecuteQuery(sql).Tables[0];
+            var results = new List<BuildsSummary>();
+            foreach (DataRow tableRow in table.Rows)
+            {
+                results.Add(new BuildsSummary
+                {
+                    Department = tableRow[0].ToString(),
+                    WeekEnd = ((DateTime)tableRow[2]).Date,
+                    Value = ((decimal)tableRow[3]),
+                    DaysToBuild = ((decimal)tableRow[4]),
+                });
+            }
+
+            return results.OrderBy(s => s.WeekEnd);
+        }
+    }
+}

--- a/src/Proxy/LRPPack.cs
+++ b/src/Proxy/LRPPack.cs
@@ -1,6 +1,5 @@
 ﻿namespace Linn.Production.Proxy
 {
-    using System;
     using System.Data;
 
     using Domain.LinnApps.RemoteServices;

--- a/src/Service.Host/client/src/components/App.js
+++ b/src/Service.Host/client/src/components/App.js
@@ -16,14 +16,14 @@ function App() {
             </List>
             <Typography variant="h6">Reports</Typography>
             <List>
+                <ListItem component={Link} to="/production/reports/builds-summary/options" button>
+                    <Typography color="primary">Builds Sumary Report</Typography>
+                </ListItem>
                 <ListItem
                     component={Link}
                     to="/production/maintenance/works-orders/outstanding-works-orders-report"
                     button
                 >
-                    <Typography color="primary">Builds Sumary Report</Typography>
-                </ListItem>
-                <ListItem component={Link} to="/production/reports/builds-summary/options" button>
                     <Typography color="primary">Outstanding Works Orders Report</Typography>
                 </ListItem>
             </List>


### PR DESCRIPTION
- referncing #55, linq query generated is way too slow

- I've just hardcoded in some sql that runs faster and returns same results

- I left the infrastructure code in there for now in case anyone needs it for other reports

- I've also left the repository that built the linq query in in case anyone has any ideas how to speed it up. If not I'll delete it