### PR TITLE
Assembly Fail Fault Code create route fix

### DIFF
--- a/src/Service.Host/client/src/components/assemblyFails/AssemblyFailFaultCode.js
+++ b/src/Service.Host/client/src/components/assemblyFails/AssemblyFailFaultCode.js
@@ -157,7 +157,7 @@ AssemblyFailFaultCode.propTypes = {
         explanation: PropTypes.string,
         dateCancelled: PropTypes.string
     }),
-    editStatus: PropTypes.bool.isRequired,
+    editStatus: PropTypes.string.isRequired,
     setEditStatus: PropTypes.func.isRequired,
     addItem: PropTypes.func.isRequired,
     updateItem: PropTypes.func.isRequired,

--- a/src/Service.Host/client/src/containers/assemblyFails/AssemblyFailFaultCode.js
+++ b/src/Service.Host/client/src/containers/assemblyFails/AssemblyFailFaultCode.js
@@ -27,7 +27,8 @@ const mapDispatchToProps = {
     initialise,
     addItem: assemblyFailFaultCodeActions.add,
     setSnackbarVisible: assemblyFailFaultCodeActions.setSnackbarVisible,
-    setEditStatus: assemblyFailFaultCodeActions.setEditStatus
+    setEditStatus: assemblyFailFaultCodeActions.setEditStatus,
+    updateItem: assemblyFailFaultCodeActions.update
 };
 
 export default connect(

--- a/src/Service.Host/client/src/containers/assemblyFails/CreateAssemblyFailFaultCode.js
+++ b/src/Service.Host/client/src/containers/assemblyFails/CreateAssemblyFailFaultCode.js
@@ -15,7 +15,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
     addItem: assemblyFailFaultCodeActions.add,
     setSnackbarVisible: assemblyFailFaultCodeActions.setSnackbarVisible,
-    setEditStatus: assemblyFailFaultCodeActions.setEditStatus
+    setEditStatus: assemblyFailFaultCodeActions.setEditStatus,
+    updateItem: assemblyFailFaultCodeActions.update
 };
 
 export default connect(

--- a/src/Service/Modules/AssemblyFailsModule.cs
+++ b/src/Service/Modules/AssemblyFailsModule.cs
@@ -27,10 +27,11 @@
              this.Get("/production/quality/assembly-fails", _ => this.Search());
              this.Put("/production/quality/assembly-fails/{id}", parameters => this.Update(parameters.id));
              this.Get("/production/quality/assembly-fail-fault-codes", _ => this.GetFaultCodes());
+             this.Get("/production/quality/assembly-fail-fault-codes/create", _ => this.GetApp());
              this.Get(
                  "/production/quality/assembly-fail-fault-codes/{id*}",
                  parameters => this.GetFaultCode(parameters.id));
-            this.Post("/production/quality/assembly-fail-fault-codes", _ => this.AddFaultCode());
+             this.Post("/production/quality/assembly-fail-fault-codes", _ => this.AddFaultCode());
              this.Put(
                  "/production/quality/assembly-fail-fault-codes/{id*}",
                  parameters => this.UpdateFaultCode(parameters.id));
@@ -87,13 +88,13 @@
                 .WithView("Index");
         }
 
+        private object GetApp()
+        {
+            return this.Negotiate.WithModel(ApplicationSettings.Get()).WithView("Index");
+        }
+
         private object GetFaultCode(string id)
         {
-            if (id.ToLower().Equals("create"))
-            {
-                return this.Negotiate.WithModel(ApplicationSettings.Get()).WithView("Index");
-            }
-
             var result = this.faultCodeService.GetById(id);
             return this.Negotiate
                 .WithModel(result)

--- a/src/Service/Modules/AssemblyFailsModule.cs
+++ b/src/Service/Modules/AssemblyFailsModule.cs
@@ -89,6 +89,11 @@
 
         private object GetFaultCode(string id)
         {
+            if (id.ToLower().Equals("create"))
+            {
+                return this.Negotiate.WithModel(ApplicationSettings.Get()).WithView("Index");
+            }
+
             var result = this.faultCodeService.GetById(id);
             return this.Negotiate
                 .WithModel(result)

--- a/tests/Integration/Service.Tests/AssemblyFailsUtilityModuleSpecs/WhenGettingFaultCodeCreateRoute.cs
+++ b/tests/Integration/Service.Tests/AssemblyFailsUtilityModuleSpecs/WhenGettingFaultCodeCreateRoute.cs
@@ -1,0 +1,23 @@
+﻿namespace Linn.Production.Service.Tests.AssemblyFailsUtilityModuleSpecs
+{
+    using NSubstitute;
+
+    using NUnit.Framework;
+
+    public class WhenGettingFaultCodeCreateRoute : ContextBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            this.Response = this.Browser.Get(
+                "/production/quality/assembly-fail-fault-codes/create",
+                with => { with.Header("Accept", "application/json"); }).Result;
+        }
+
+        [Test]
+        public void ShouldNotCallService()
+        {
+            this.FaultCodeService.DidNotReceive().GetById(Arg.Any<string>());
+        }
+    }
+}


### PR DESCRIPTION
I've added a check for a fault code /create route - I was catching all possible ids as many have `/` characters which weren't properly caught by nancy. 

I went half way down the route of using a request parameter `?faultCode="bleh"` but I stopped as I wasn't sure how this would work in a conditional with react router.

If the request param seems cleaner I can implement that instead.