### PR TITLE
change to target days instead of a fixed 5 days for delivery performance

### DIFF
--- a/src/Domain.LinnApps/Models/PtlStatPrioritySummary.cs
+++ b/src/Domain.LinnApps/Models/PtlStatPrioritySummary.cs
@@ -27,14 +27,18 @@
 
         public decimal Percentile95 { get; set; }
 
-        public decimal PercBy5Day()
+        public int? TargetDays { get; set; } = null;
+
+        public int WithinTargetDays { get; set; } = 0;
+
+        public decimal PercByTargetDays()
         {
             if (this.Triggers == 0)
             {
                 return 0;
             }
 
-            return decimal.Round((((decimal)(this.Triggers - this.Gt5Day)) / (decimal)this.Triggers) * 100);
+            return decimal.Round((((decimal)(this.WithinTargetDays)) / (decimal)this.Triggers) * 100);
         }
 
         public decimal AvgTurnaround()
@@ -74,6 +78,17 @@
             else
             {
                 this.Gt5Day++;
+            }
+
+            if (this.TargetDays == null)
+            {
+                this.TargetDays = stat.TargetDays();
+            }
+
+            if (stat.WorkingDays < (this.TargetDays + 1))
+            {
+                // remembering that 3.8 still counts as within 3 days cos thats how current stats work
+                this.WithinTargetDays++;
             }
         }
 

--- a/src/Domain.LinnApps/PtlStat.cs
+++ b/src/Domain.LinnApps/PtlStat.cs
@@ -26,7 +26,7 @@
 
         public decimal WorkingDays { get; set; }
 
-        public decimal TargetDays()
+        public int TargetDays()
         {
             if (this.BuildGroup == "EP")
             {

--- a/src/Domain.LinnApps/Reports/DeliveryPeformanceReportService.cs
+++ b/src/Domain.LinnApps/Reports/DeliveryPeformanceReportService.cs
@@ -27,6 +27,8 @@
             var stats = this.ptlStatRepository.FilterBy(s =>
                 s.CitCode == citCode && s.DateCompleted >= dates.fromDate && s.DateCompleted <= dates.toDate).ToList();
 
+            var targetDays = stats.FirstOrDefault()?.TargetDays();
+
             var model = new ResultsModel();
             model.ReportTitle = new NameModel($"Production Delivery Performance {dates.fromDate.ToString("dd-MMM-yy")} - {dates.toDate.ToString("dd-MMM-yy")}");
 
@@ -39,7 +41,7 @@
             model.AddColumn("3day", "3 Day");
             model.AddColumn("4day", "4 Day");
             model.AddColumn("5day", "5 Day");
-            model.AddColumn("percBy5days", "% by 5 days");
+            model.AddColumn("percByTargetDays", $"% by {targetDays} days");
             model.AddColumn("gt5day", "> 5 Day");
 
             var priorities = stats.Select(s => s.PtlPriority).Distinct().OrderBy(s => s);
@@ -70,7 +72,7 @@
                 model.SetGridTextValue(row.RowIndex, model.ColumnIndex("3day"), summary.ThreeDay.ToString());
                 model.SetGridTextValue(row.RowIndex, model.ColumnIndex("4day"), summary.FourDay.ToString());
                 model.SetGridTextValue(row.RowIndex, model.ColumnIndex("5day"), summary.FiveDay.ToString());
-                model.SetGridTextValue(row.RowIndex, model.ColumnIndex("percBy5days"), summary.PercBy5Day().ToString());
+                model.SetGridTextValue(row.RowIndex, model.ColumnIndex("percByTargetDays"), summary.PercByTargetDays().ToString());
                 model.SetGridTextValue(row.RowIndex, model.ColumnIndex("gt5day"), summary.Gt5Day.ToString());
             }
 

--- a/tests/Unit/Domain.Tests/DeliveryPerformanceReportSpecs/WhenGettingReport.cs
+++ b/tests/Unit/Domain.Tests/DeliveryPerformanceReportSpecs/WhenGettingReport.cs
@@ -20,12 +20,12 @@
         {
             var statistics = new List<PtlStat>()
             {
-                new PtlStat { PtlPriority = 1, WorkingDays = 0.5m},
-                new PtlStat { PtlPriority = 1, WorkingDays = 1 },
-                new PtlStat { PtlPriority = 1, WorkingDays = 2.3m },
-                new PtlStat { PtlPriority = 1, WorkingDays = 10m },
-                new PtlStat { PtlPriority = 2, WorkingDays = 4.1m },
-                new PtlStat { PtlPriority = 2, WorkingDays = 4.1m }
+                new PtlStat { PtlPriority = 1, WorkingDays = 0.5m, BuildGroup = "PP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 1, BuildGroup = "PP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 2.3m, BuildGroup = "PP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 10m, BuildGroup = "PP" },
+                new PtlStat { PtlPriority = 2, WorkingDays = 4.1m, BuildGroup = "PP" },
+                new PtlStat { PtlPriority = 2, WorkingDays = 4.1m, BuildGroup = "PP" }
             };
             this.PtlStatRepository.FilterBy(Arg.Any<Expression<Func<PtlStat, bool>>>())
                 .Returns(statistics.AsQueryable());
@@ -82,10 +82,10 @@
         }
 
         [Test]
-        public void ShouldHaveCorrectPercBy5Day()
+        public void ShouldHaveCorrectPercByTargetDays()
         {
-            this.result.GetGridTextValue(this.result.RowIndex("1"), this.result.ColumnIndex("percBy5days")).Should().Be("75");
-            this.result.GetGridTextValue(this.result.RowIndex("2"), this.result.ColumnIndex("percBy5days")).Should().Be("100");
+            this.result.GetGridTextValue(this.result.RowIndex("1"), this.result.ColumnIndex("percByTargetDays")).Should().Be("75");
+            this.result.GetGridTextValue(this.result.RowIndex("2"), this.result.ColumnIndex("percByTargetDays")).Should().Be("100");
         }
     }
 }

--- a/tests/Unit/Domain.Tests/PtlStatPrioritySummarySpecs/WhenConstructingPtlStatPrioritySummaryFor3DayTarget.cs
+++ b/tests/Unit/Domain.Tests/PtlStatPrioritySummarySpecs/WhenConstructingPtlStatPrioritySummaryFor3DayTarget.cs
@@ -6,7 +6,7 @@
     using Linn.Production.Domain.LinnApps.Models;
     using NUnit.Framework;
 
-    public class WhenConstructingPtlStatPrioritySummary
+    public class WhenConstructingPtlStatPrioritySummaryFor3DayTarget
     {
         protected PtlStatPrioritySummary Sut { get; set; }
 
@@ -15,11 +15,11 @@
         {
             var stats = new List<PtlStat>()
             {
-                new PtlStat { PtlPriority = 1, WorkingDays = 0m, BuildGroup = "PP" },
-                new PtlStat { PtlPriority = 1, WorkingDays = 1m, BuildGroup = "PP" },
-                new PtlStat { PtlPriority = 1, WorkingDays = 2m, BuildGroup = "PP" },
-                new PtlStat { PtlPriority = 1, WorkingDays = 4m, BuildGroup = "PP" },
-                new PtlStat { PtlPriority = 1, WorkingDays = 8m, BuildGroup = "PP" }
+                new PtlStat { PtlPriority = 1, WorkingDays = 0m, BuildGroup = "CP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 1m, BuildGroup = "CP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 2m, BuildGroup = "CP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 4m, BuildGroup = "CP" },
+                new PtlStat { PtlPriority = 1, WorkingDays = 8m, BuildGroup = "CP" }
             };
 
             this.Sut = new PtlStatPrioritySummary(1);
@@ -61,7 +61,7 @@
         [Test]
         public void ShouldHaveCorrectpercByTargetDays()
         {
-            this.Sut.PercByTargetDays().Should().Be(80);
+            this.Sut.PercByTargetDays().Should().Be(60);
         }
     }
 }


### PR DESCRIPTION
Some metalwork teams have OSR delivery performance of 3 days rather than 5.  This was partially addressed in code but have now fixed it properly.

Fixes #256 