### PR TITLE
fixing production trigger context menu

### DIFF
--- a/src/Service.Host/client/src/components/reports/triggers/TriggersList.js
+++ b/src/Service.Host/client/src/components/reports/triggers/TriggersList.js
@@ -90,9 +90,28 @@ function TriggersList({ triggers, jobref, citcode }) {
                                 >
                                     <MenuItem>Facts</MenuItem>
                                 </Link>
-                                <MenuItem>Edit Story</MenuItem>
-                                <MenuItem>Works Order</MenuItem>
-                                <MenuItem>Build Plan</MenuItem>
+                                <Link
+                                    component={RouterLink}
+                                    to={`/production/maintenance/production-trigger-levels/${encodeURIComponent(
+                                        m.partNumber
+                                    )}`}
+                                >
+                                    <MenuItem>Edit Trigger</MenuItem>
+                                </Link>
+                                <Link
+                                    component={RouterLink}
+                                    to={`/production/works-orders/create?partNumber=${encodeURIComponent(
+                                        m.partNumber
+                                    )}`}
+                                >
+                                    <MenuItem>Raise Works Order</MenuItem>
+                                </Link>
+                                <Link
+                                    component={RouterLink}
+                                    to="/production/maintenance/build-plans"
+                                >
+                                    <MenuItem>Build Plan</MenuItem>
+                                </Link>
                             </ContextMenu>
                         </TableCell>
                     </TableRow>

--- a/src/Service.Host/client/src/components/worksOrders/WorksOrder.js
+++ b/src/Service.Host/client/src/components/worksOrders/WorksOrder.js
@@ -68,7 +68,8 @@ function WorksOrder({
     clearErrors,
     serialNumbers,
     fetchSerialNumbers,
-    previousPath
+    previousPath,
+    options
 }) {
     const [worksOrder, setWorksOrder] = useState({});
     const [prevWorksOrder, setPrevWorksOrder] = useState({});
@@ -138,6 +139,17 @@ function WorksOrder({
             }));
         }
     }, [worksOrderDetails, editStatus, creating]);
+
+    useEffect(() => {
+        if (creating() && options.partNumber && !worksOrder.partNumber) {
+            fetchWorksOrderDetails(options.partNumber);
+            setWorksOrder({
+                ...worksOrder,
+                docType: 'WO',
+                partNumber: options.partNumber
+            });
+        }
+    }, [options, creating, worksOrder, fetchWorksOrderDetails]);
 
     const handleCancelClick = () => {
         setWorksOrder(item);
@@ -639,7 +651,8 @@ WorksOrder.propTypes = {
     defaultWorksOrderPrinter: PropTypes.string,
     fetchSerialNumbers: PropTypes.func.isRequired,
     serialNumbers: PropTypes.arrayOf(PropTypes.shape()),
-    previousPath: PropTypes.string.isRequired
+    previousPath: PropTypes.string.isRequired,
+    options: PropTypes.shape({})
 };
 
 WorksOrder.defaultProps = {
@@ -663,7 +676,8 @@ WorksOrder.defaultProps = {
     searchParts: null,
     clearPartsSearch: null,
     defaultWorksOrderPrinter: 'Prod',
-    serialNumbers: []
+    serialNumbers: [],
+    options: {}
 };
 
 export default WorksOrder;

--- a/src/Service.Host/client/src/containers/worksOrders/CreateWorksOrder.js
+++ b/src/Service.Host/client/src/containers/worksOrders/CreateWorksOrder.js
@@ -4,6 +4,7 @@ import {
     getItemErrorDetailMessage,
     initialiseOnMount
 } from '@linn-it/linn-form-components-library';
+import queryString from 'query-string';
 import WorksOrder from '../../components/worksOrders/WorksOrder';
 import worksOrderSelectors from '../../selectors/worksOrderSelectors';
 import worksOrderActions from '../../actions/worksOrderActions';
@@ -20,12 +21,18 @@ import printWorksOrderAioLabelsSelectors from '../../selectors/printWorksOrderAi
 import * as itemTypes from '../../itemTypes';
 import * as processTypes from '../../processTypes';
 
-const mapStateToProps = state => ({
+const getOptions = ownProps => {
+    const options = queryString.parse(ownProps.location.search);
+    return options || {};
+};
+
+const mapStateToProps = (state, ownProps) => ({
     itemErrors: getItemErrors(state),
     worksOrderError: getItemErrorDetailMessage(state, itemTypes.worksOrder.item),
     worksOrderDetailsError: getItemErrorDetailMessage(state, itemTypes.worksOrderDetails.item),
     editStatus: 'create',
     loading: worksOrderSelectors.getLoading(state),
+    options: getOptions(ownProps),
     snackbarVisible: worksOrderSelectors.getSnackbarVisible(state),
     employees: employeesSelectors.getItems(state),
     worksOrderDetails: worksOrderDetailsSelectors.getItem(state),

--- a/src/Service.Host/package-lock.json
+++ b/src/Service.Host/package-lock.json
@@ -3046,7 +3046,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -3205,7 +3205,7 @@
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
       "dev": true
     },
     "async": {
@@ -3498,7 +3498,7 @@
     "babel-jest": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-      "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+      "integrity": "sha1-LOBZUZqTdKLEbyRVtvvvWtddhj4=",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "^4.0.0",
@@ -3557,7 +3557,7 @@
     "babel-plugin-jest-hoist": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-      "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+      "integrity": "sha1-LO9jclm9S2KKbKzgOd5fzRTbsAY=",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -3594,7 +3594,7 @@
     "babel-preset-jest": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-      "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+      "integrity": "sha1-/50rzgir2Y6KNtmopRibkXO4Vjg=",
       "dev": true,
       "requires": {
         "babel-plugin-jest-hoist": "^21.2.0",
@@ -4495,7 +4495,7 @@
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3"
@@ -5150,7 +5150,7 @@
     },
     "css-loader": {
       "version": "0.28.11",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
       "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "dev": true,
       "requires": {
@@ -8000,7 +8000,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "function.prototype.name": {
       "version": "1.1.2",
@@ -8969,7 +8969,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -9218,7 +9218,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
@@ -11926,7 +11926,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -13182,7 +13182,7 @@
     "postcss": {
       "version": "5.2.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
@@ -13368,7 +13368,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -13521,7 +13521,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -13550,7 +13550,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -13579,7 +13579,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -14047,7 +14047,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         }
       }
     },
@@ -14579,7 +14579,7 @@
     "redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
       "requires": {
         "lodash": "^4.2.1",
         "lodash-es": "^4.2.1",
@@ -14673,7 +14673,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -15487,7 +15487,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "scheduler": {
@@ -16357,7 +16357,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -17098,7 +17098,7 @@
     "url-loader": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
-      "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+      "integrity": "sha1-oAenEJYg6dmI0UvOZ3od7Lmpk/c=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.0.2",


### PR DESCRIPTION
Fixing the production triggers report context menu to not just contain placeholders
- Edit Story -> link to the production trigger levels page where you can change the story
- Raise Works Order - creates a works order for that part number using some effect hook magic
- Build Plan - just goes to the build plan page because even the existing functionality on the form doesn't actually work.