### PR TITLE
allow 3 digits in kanban size inputs

### DIFF
--- a/src/Service.Host/client/src/components/productionTriggerLevels/TriggerLevel.js
+++ b/src/Service.Host/client/src/components/productionTriggerLevels/TriggerLevel.js
@@ -332,7 +332,7 @@ function TriggerLevel({
                                         <InputField
                                             value={triggerLevel.kanbanSize}
                                             label="Kanban Size"
-                                            maxLength={2}
+                                            maxLength={3}
                                             type="number"
                                             fullWidth
                                             helperText={
@@ -349,7 +349,7 @@ function TriggerLevel({
                                             value={triggerLevel.maximumKanbans}
                                             label="Maximum Kanbans"
                                             type="number"
-                                            maxLength={2}
+                                            maxLength={3}
                                             fullWidth
                                             helperText={
                                                 maximumKanbansInvalid()


### PR DESCRIPTION
Ticket from Scott. Back end & db don't need changed they already support 6 digits