### PR TITLE
fix cancel/back

### DIFF
--- a/src/Service.Host/client/src/components/worksOrders/WorksOrder.js
+++ b/src/Service.Host/client/src/components/worksOrders/WorksOrder.js
@@ -89,6 +89,7 @@ function WorksOrder({
     const [printerGroup, setPrinterGroup] = useState('Prod');
     const [viewSernos, setViewsernos] = useState(false);
     const [dialogOpen, setDialogOpen] = useState(false);
+    const [cancelClicked, setCancelClicked] = useState(false);
 
     const printerGroups = ['Prod', 'DSM', 'Flexible', 'Kiko', 'LP12', 'Metalwork', 'SpeakerCover'];
 
@@ -159,7 +160,7 @@ function WorksOrder({
     }, [worksOrderDetails, editStatus, creating]);
 
     useEffect(() => {
-        if (creating() && options.partNumber && !worksOrder.partNumber) {
+        if (creating() && options.partNumber && !worksOrder.partNumber && !cancelClicked) {
             fetchWorksOrderDetails(options.partNumber);
             setWorksOrder({
                 ...worksOrder,
@@ -167,10 +168,11 @@ function WorksOrder({
                 partNumber: options.partNumber
             });
         }
-    }, [options, creating, worksOrder, fetchWorksOrderDetails]);
+    }, [options, creating, worksOrder, fetchWorksOrderDetails, cancelClicked]);
 
     const handleCancelClick = () => {
-        setWorksOrder(item);
+        setCancelClicked(!cancelClicked);
+        setWorksOrder({ ...item, docType: 'WO' });
         setEditStatus('view');
     };
 
@@ -714,8 +716,15 @@ function WorksOrder({
 }
 
 WorksOrder.propTypes = {
-    item: PropTypes.shape({}),
-    worksOrderDetails: PropTypes.shape({}),
+    item: PropTypes.shape({ orderNumber: PropTypes.number, partNumber: PropTypes.string }),
+    worksOrderDetails: PropTypes.shape({
+        workStationCode: PropTypes.string,
+        departmentCode: PropTypes.string,
+        quantityToBuild: PropTypes.string,
+        auditDisclaimer: PropTypes.string,
+        partDescription: PropTypes.string,
+        departmentDescription: PropTypes.string
+    }),
     editStatus: PropTypes.string.isRequired,
     worksOrderDetailsError: PropTypes.string,
     worksOrderError: PropTypes.string,
@@ -753,7 +762,7 @@ WorksOrder.propTypes = {
     fetchSerialNumbers: PropTypes.func,
     serialNumbers: PropTypes.arrayOf(PropTypes.shape()),
     options: PropTypes.shape({ partNumber: PropTypes.string }),
-    profile: PropTypes.shape({}),
+    profile: PropTypes.shape({ employee: PropTypes.string }),
     previousPaths: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/src/Service.Host/client/src/containers/Page.js
+++ b/src/Service.Host/client/src/containers/Page.js
@@ -1,10 +1,12 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { Page, getRequestErrors } from '@linn-it/linn-form-components-library';
+import config from '../config';
 
 const mapStateToProps = (state, ownProps) => ({
     requestErrors: getRequestErrors(state),
     showRequestErrors: ownProps.showRequestErrors,
+    homeUrl: config.appRoot,
     width: ownProps.width
 });
 

--- a/src/Service.Host/package-lock.json
+++ b/src/Service.Host/package-lock.json
@@ -2001,9 +2001,9 @@
       }
     },
     "@linn-it/linn-form-components-library": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/@linn-it/linn-form-components-library/-/linn-form-components-library-11.1.6.tgz",
-      "integrity": "sha512-Adku55aTiKRKDlju9E8VF3pF4cEeWYsmF+t6c5nMcXD6vl0NquxUUSeZbnllHfrgeX3wa4cCMaGKIIClfn+xGg==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@linn-it/linn-form-components-library/-/linn-form-components-library-11.4.1.tgz",
+      "integrity": "sha512-5PGzVEO86EBhkCpmPcZF/a9F+mLGOZFsgtVhb6Mna6xg4aa+O5/74VqpYsMpzguyJ2P1BxXUScL19b7+uFXqEw==",
       "requires": {
         "classnames": "^2.2.6",
         "clsx": "^1.1.0",
@@ -4420,9 +4420,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "cli-cursor": {
       "version": "3.1.0",

--- a/src/Service.Host/package.json
+++ b/src/Service.Host/package.json
@@ -76,7 +76,7 @@
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.8.3",
     "@date-io/moment": "^1.3.13",
-    "@linn-it/linn-form-components-library": "11.1.6",
+    "@linn-it/linn-form-components-library": "11.4.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/pickers": "^3.2.10",


### PR DESCRIPTION
@richardiphillips As far as I could see the works order form is already using the smartGoBack function. It seems to correctly take you back to the trigger levels report - if you click through from there to raise a WO, clicking back does actually take you back to the report.

I did fix a weird bug related to cancel button though, hence the PR, which might have been what Mark meant? 

I can catch up with him about it