### PR TITLE
encode fault code urls so that fault codes with / in them will work

### DIFF
--- a/src/Facade/ResourceBuilders/PartFailFaultCodeResourceBuilder.cs
+++ b/src/Facade/ResourceBuilders/PartFailFaultCodeResourceBuilder.cs
@@ -24,7 +24,7 @@
 
         public string GetLocation(PartFailFaultCode faultCode)
         {
-            return $"/production/quality/part-fail-fault-codes/{faultCode.FaultCode}";
+            return $"/production/quality/part-fail-fault-codes/{Uri.EscapeDataString(faultCode.FaultCode)}";
         }
 
         object IResourceBuilder<PartFailFaultCode>.Build(PartFailFaultCode faultCode) => this.Build(faultCode);


### PR DESCRIPTION
view/edit pages linked to weren't loading due to slash making it seem like a whole different page

http://rndsupport.linn.co.uk/scp/tickets.php?id=15147