### PR TITLE
Change Failed Parts Qty to Decimal for Scott Ticket

### DIFF
--- a/src/Domain.LinnApps/Reports/ProductionMeasuresReportService.cs
+++ b/src/Domain.LinnApps/Reports/ProductionMeasuresReportService.cs
@@ -41,7 +41,7 @@
                               {
                                   new AxisDetailsModel("Part Number", GridDisplayType.TextValue) { AllowWrap = false },
                                   new AxisDetailsModel("Description", GridDisplayType.TextValue),
-                                  new AxisDetailsModel("Qty"),
+                                  new AxisDetailsModel("Qty") { DecimalPlaces = 1 },
                                   new AxisDetailsModel("Total Value") { DecimalPlaces = 2 },
                                   new AxisDetailsModel("Date Booked", GridDisplayType.TextValue) { AllowWrap = false },
                                   new AxisDetailsModel("User Name", GridDisplayType.TextValue),

--- a/src/Domain.LinnApps/ViewModels/FailedParts.cs
+++ b/src/Domain.LinnApps/ViewModels/FailedParts.cs
@@ -8,7 +8,7 @@
 
         public string PartDescription { get; set; }
 
-        public int Qty { get; set; }
+        public decimal Qty { get; set; }
 
         public string BatchRef { get; set; }
 

--- a/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/ContextBase.cs
+++ b/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/ContextBase.cs
@@ -51,7 +51,7 @@
                                                SupplierName = "s1",
                                                CreatedBy = "Person 1",
                                                DateBooked = 1.July(2021),
-                                               Qty = 2,
+                                               Qty = 2.5m,
                                                TotalValue = 34.34m,
                                                StoragePlace = "Store 1"
                                            },
@@ -96,7 +96,7 @@
                                                Qty = 2,
                                                TotalValue = 34.34m,
                                                StoragePlace = "Store 1"
-                                           },
+                                           }
                                    };
             this.FailedPartsRepository.FindAll().Returns(this.FailedParts.AsQueryable());
 

--- a/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/WhenGettingFailedPartsReportForAPart.cs
+++ b/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/WhenGettingFailedPartsReportForAPart.cs
@@ -37,7 +37,7 @@
             report.GetGridTextValue(report.RowIndex("1"), report.ColumnIndex("Part Number")).Should().Be("p1");
             report.GetGridTextValue(report.RowIndex("0"), report.ColumnIndex("Description")).Should().Be("p1 desc");
             report.GetGridTextValue(report.RowIndex("1"), report.ColumnIndex("Description")).Should().Be("p1 desc");
-            report.GetGridValue(report.RowIndex("0"), report.ColumnIndex("Qty")).Should().Be(2);
+            report.GetGridValue(report.RowIndex("0"), report.ColumnIndex("Qty")).Should().Be(2.5m);
             report.GetGridValue(report.RowIndex("1"), report.ColumnIndex("Qty")).Should().Be(2);
             report.GetGridValue(report.RowIndex("0"), report.ColumnIndex("Total Value")).Should().Be(34.34m);
             report.GetGridValue(report.RowIndex("1"), report.ColumnIndex("Total Value")).Should().Be(808.08m);

--- a/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/WhenGettingReportForAllCits.cs
+++ b/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/WhenGettingReportForAllCits.cs
@@ -42,7 +42,7 @@
             report1.GetGridTextValue(report1.RowIndex("1"), report1.ColumnIndex("Part Number")).Should().Be("p2");
             report1.GetGridTextValue(report1.RowIndex("0"), report1.ColumnIndex("Description")).Should().Be("p1 desc");
             report1.GetGridTextValue(report1.RowIndex("1"), report1.ColumnIndex("Description")).Should().Be("p2 desc");
-            report1.GetGridValue(report1.RowIndex("0"), report1.ColumnIndex("Qty")).Should().Be(2);
+            report1.GetGridValue(report1.RowIndex("0"), report1.ColumnIndex("Qty")).Should().Be(2.5m);
             report1.GetGridValue(report1.RowIndex("1"), report1.ColumnIndex("Qty")).Should().Be(34);
             report1.GetGridValue(report1.RowIndex("0"), report1.ColumnIndex("Total Value")).Should().Be(34.34m);
             report1.GetGridValue(report1.RowIndex("1"), report1.ColumnIndex("Total Value")).Should().Be(10m);

--- a/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/WhenGettingReportForCit.cs
+++ b/tests/Unit/Domain.Tests/ProductionMeasuresReportServiceSpecs/WhenGettingReportForCit.cs
@@ -37,7 +37,7 @@
             report1.GetGridTextValue(report1.RowIndex("1"), report1.ColumnIndex("Part Number")).Should().Be("p2");
             report1.GetGridTextValue(report1.RowIndex("0"), report1.ColumnIndex("Description")).Should().Be("p1 desc");
             report1.GetGridTextValue(report1.RowIndex("1"), report1.ColumnIndex("Description")).Should().Be("p2 desc");
-            report1.GetGridValue(report1.RowIndex("0"), report1.ColumnIndex("Qty")).Should().Be(2);
+            report1.GetGridValue(report1.RowIndex("0"), report1.ColumnIndex("Qty")).Should().Be(2.5m);
             report1.GetGridValue(report1.RowIndex("1"), report1.ColumnIndex("Qty")).Should().Be(34);
             report1.GetGridValue(report1.RowIndex("0"), report1.ColumnIndex("Total Value")).Should().Be(34.34m);
             report1.GetGridValue(report1.RowIndex("1"), report1.ColumnIndex("Total Value")).Should().Be(10m);


### PR DESCRIPTION
http://rndsupport.linn.co.uk/scp/tickets.php?id=16925

Scott requesting to be able to see halves in the qty. Changed from int to decimal.

Altered one of the tests to use a decimal rather than just an integer. Originally added a whole other new Failedpart but felt like it altered too many of the existing tests and that this was maybe a simpler option whilst also proving functionality works. Happy to change it/take it out though as it's just a minor thing - thought it'd be worth having anyway. 